### PR TITLE
Fix fatal crash on startup

### DIFF
--- a/src/main/java/io/github/townyadvanced/townyresources/settings/TownyResourcesConfigNodes.java
+++ b/src/main/java/io/github/townyadvanced/townyresources/settings/TownyResourcesConfigNodes.java
@@ -228,8 +228,8 @@ public enum TownyResourcesConfigNodes {
 			"{mushrooms, 100, 1, BROWN_MUSHROOM, RED_MUSHROOM}," +
 			"{apple_trees, 100, 0.125, APPLE}," +
 			"{vines, 100, 0.25, VINE}," +
-			"{nether_wart, 1, NETHER_WART}," +
-			"{chorus_fruit, 1, CHORUS_FRUIT}," +		
+			"{nether_wart, 100, 1, NETHER_WART}," +
+			"{chorus_fruit, 100, 1, CHORUS_FRUIT}," +		
 			"{fish, 100, 1, COD, SALMON, PUFFERFISH, TROPICAL_FISH}," +
 			"{wool, 100, 0.5, WHITE_WOOL}," +			
 			"{gunpowder, 200, 0.25, GUNPOWDER}," +


### PR DESCRIPTION
The default weight for the nether wart and chorus fruit items had originally been omitted, which had caused a crash on startup when attempting to load the material type as the stack amount.

This fixes the crash, and sets the nether wart and chorus fruit weight to 100.