### PR TITLE
Tr 28 - Add warning message if a discovery cannot be immediately produced

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.github.townyadvanced</groupId>
   <artifactId>TownyResources</artifactId>
-  <version>0.0.14</version>
+  <version>0.0.15</version>
   <name>townyresources</name> <!-- Leave lower-cased -->
 
   <properties>

--- a/src/main/java/io/github/townyadvanced/townyresources/commands/TownyResourcesCommand.java
+++ b/src/main/java/io/github/townyadvanced/townyresources/commands/TownyResourcesCommand.java
@@ -1,10 +1,10 @@
 package io.github.townyadvanced.townyresources.commands;
 
-import com.gmail.goosius.siegewar.settings.Translation;
 import com.palmergames.bukkit.towny.TownyAPI;
 import com.palmergames.bukkit.towny.TownyEconomyHandler;
 import com.palmergames.bukkit.towny.TownyMessaging;
 import com.palmergames.bukkit.towny.TownyUniverse;
+import com.palmergames.bukkit.towny.TownySettings;
 import com.palmergames.bukkit.towny.confirmations.Confirmation;
 import com.palmergames.bukkit.towny.exceptions.TownyException;
 import com.palmergames.bukkit.towny.object.Nation;
@@ -122,6 +122,12 @@ public class TownyResourcesCommand implements CommandExecutor, TabCompleter {
 
 		//Send confirmation request message
 		TownyMessaging.sendMessage(player, TownyResourcesTranslation.of("msg_confirm_survey", town.getName(), surveyLevel, TownyEconomyHandler.getFormattedBalance(surveyCost)));
+		//Send warning if town level is too low
+		int requiredTownLevel = TownyResourcesSettings.getProductionTownLevelRequirementPerResourceLevel().get(indexOfNextResourceLevel);
+		int actualTownLevel = TownySettings.calcTownLevelId(town);
+		if(actualTownLevel < requiredTownLevel) {
+			TownyMessaging.sendMessage(player, TownyResourcesTranslation.of("msg_confirm_survey_town_level_warning", requiredTownLevel, actualTownLevel));
+		}
 		Resident resident = TownyUniverse.getInstance().getResident(player.getUniqueId());
 		Confirmation.runOnAccept(() -> {
 			try {

--- a/src/main/resources/chinese.yml
+++ b/src/main/resources/chinese.yml
@@ -1,5 +1,5 @@
 name: TownyResources
-version: 0.04
+version: 0.05
 language: chinese
 author: Nailm
 website: 'https://github.com/TownyAdvanced/TownyResources'
@@ -149,3 +149,6 @@ resource_category_slime: '史莱姆, 异世界的史莱姆'
 msg_confirm_survey: "You are about to survey the town of %s for its level %d resource. This will cost %s. Do you wish to proceed ?"
 msg_err_level_x_resource_already_discovered: "The level %d resource has already been discovered."
 msg_err_cannot_collect_unknown_material: "Cannot collect the following unknown material: %s"
+
+#Added in 0.05
+msg_confirm_survey_town_level_warning: "&cWARNING: Your town does not have a large enough population to produce this resource. Required Town Level: %d, Actual Town Level %d."

--- a/src/main/resources/chinese.yml
+++ b/src/main/resources/chinese.yml
@@ -151,4 +151,4 @@ msg_err_level_x_resource_already_discovered: "The level %d resource has already 
 msg_err_cannot_collect_unknown_material: "Cannot collect the following unknown material: %s"
 
 #Added in 0.05
-msg_confirm_survey_town_level_warning: "&cWARNING: Your town does not have a large enough population to produce this resource. Required Town Level: %d, Actual Town Level %d."
+msg_confirm_survey_town_level_warning: "&cWARNING: Although the resource can be discovered, the town does not have a large enough population to produce it. Required Town Level: %d, Actual Town Level %d."

--- a/src/main/resources/english.yml
+++ b/src/main/resources/english.yml
@@ -1,5 +1,5 @@
 name: TownyResources
-version: 0.04
+version: 0.05
 language: english
 author: Goosius
 website: 'https://github.com/TownyAdvanced/TownyResources'
@@ -149,3 +149,6 @@ resource_category_slime: 'Slime, a nest of slimes'
 msg_confirm_survey: "You are about to survey the town of %s for its level %d resource. This will cost %s. Do you wish to proceed ?"
 msg_err_level_x_resource_already_discovered: "The level %d resource has already been discovered."
 msg_err_cannot_collect_unknown_material: "Cannot collect the following unknown material: %s"
+
+#Added in 0.05
+msg_confirm_survey_town_level_warning: "&cWARNING: Your town does not have a large enough population to produce this resource. Required Town Level: %d, Actual Town Level %d."

--- a/src/main/resources/english.yml
+++ b/src/main/resources/english.yml
@@ -151,4 +151,4 @@ msg_err_level_x_resource_already_discovered: "The level %d resource has already 
 msg_err_cannot_collect_unknown_material: "Cannot collect the following unknown material: %s"
 
 #Added in 0.05
-msg_confirm_survey_town_level_warning: "&cWARNING: Your town does not have a large enough population to produce this resource. Required Town Level: %d, Actual Town Level %d."
+msg_confirm_survey_town_level_warning: "&cWARNING: Although the resource can be discovered, the town does not have a large enough population to produce it. Required Town Level: %d, Actual Town Level %d."


### PR DESCRIPTION
Adds a warning message if a discovery cannot be immediately produced

Closes #28 

- [x] I have tested this pull request for defects on a server. 

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the SiegeWar [License](https://github.com/TownyAdvanced/SiegeWar/blob/master/LICENSE.md) for perpetuity.