### PR TITLE
Tr 29 - Add admin command to reroll all resources

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.github.townyadvanced</groupId>
   <artifactId>TownyResources</artifactId>
-  <version>0.0.15</version>
+  <version>0.0.16</version>
   <name>townyresources</name> <!-- Leave lower-cased -->
 
   <properties>

--- a/src/main/java/io/github/townyadvanced/townyresources/commands/TownyResourcesAdminCommand.java
+++ b/src/main/java/io/github/townyadvanced/townyresources/commands/TownyResourcesAdminCommand.java
@@ -1,8 +1,14 @@
 package io.github.townyadvanced.townyresources.commands;
 
+import com.palmergames.bukkit.towny.TownyMessaging;
+import com.palmergames.bukkit.towny.TownyUniverse;
+import com.palmergames.bukkit.towny.confirmations.Confirmation;
+import com.palmergames.bukkit.towny.exceptions.TownyException;
+import com.palmergames.bukkit.towny.object.Resident;
 import com.palmergames.bukkit.towny.utils.NameUtil;
 import com.palmergames.bukkit.util.ChatTools;
 import io.github.townyadvanced.townyresources.TownyResources;
+import io.github.townyadvanced.townyresources.controllers.TownResourceDiscoveryController;
 import io.github.townyadvanced.townyresources.enums.TownyResourcesPermissionNodes;
 import io.github.townyadvanced.townyresources.settings.TownyResourcesTranslation;
 import io.github.townyadvanced.townyresources.util.TownyResourcesMessagingUtil;
@@ -49,6 +55,9 @@ public class TownyResourcesAdminCommand implements CommandExecutor, TabCompleter
 				case "reload":
 					parseReloadCommand(sender);
 				break;
+				case "reroll_all_resources":
+					parseReRollCommand(sender);
+				break;
 				/*
 				 * Show help if no command found.
 				 */
@@ -64,6 +73,7 @@ public class TownyResourcesAdminCommand implements CommandExecutor, TabCompleter
 	private void showHelp(CommandSender sender) {
 		sender.sendMessage(ChatTools.formatTitle("/townyresourcesadmin"));
 		sender.sendMessage(ChatTools.formatCommand("Eg", "/tra", "reload", TownyResourcesTranslation.of("admin_help_reload")));
+		sender.sendMessage(ChatTools.formatCommand("Eg", "/tra", "reroll_all_resources", TownyResourcesTranslation.of("admin_help_reroll")));
 	}
 
 	private void parseReloadCommand(CommandSender sender) {
@@ -72,6 +82,15 @@ public class TownyResourcesAdminCommand implements CommandExecutor, TabCompleter
 			return;
 		}
 		TownyResourcesMessagingUtil.sendErrorMsg(sender, TownyResourcesTranslation.of("townyresources_failed_to_reload"));
+	}
+	
+	private void parseReRollCommand(CommandSender sender) {
+		TownyMessaging.sendMessage(sender, TownyResourcesTranslation.of("msg_confirm_reroll"));
+		Confirmation.runOnAccept(() -> {
+			TownResourceDiscoveryController.reRollAllExistingResources();
+			TownyResourcesMessagingUtil.sendGlobalMessage(TownyResourcesTranslation.of("all_resources_rerolled"));			
+		})
+		.sendTo(sender);
 	}
 }
 

--- a/src/main/java/io/github/townyadvanced/townyresources/commands/TownyResourcesAdminCommand.java
+++ b/src/main/java/io/github/townyadvanced/townyresources/commands/TownyResourcesAdminCommand.java
@@ -1,10 +1,7 @@
 package io.github.townyadvanced.townyresources.commands;
 
 import com.palmergames.bukkit.towny.TownyMessaging;
-import com.palmergames.bukkit.towny.TownyUniverse;
 import com.palmergames.bukkit.towny.confirmations.Confirmation;
-import com.palmergames.bukkit.towny.exceptions.TownyException;
-import com.palmergames.bukkit.towny.object.Resident;
 import com.palmergames.bukkit.towny.utils.NameUtil;
 import com.palmergames.bukkit.util.ChatTools;
 import io.github.townyadvanced.townyresources.TownyResources;
@@ -24,7 +21,7 @@ import java.util.List;
 
 public class TownyResourcesAdminCommand implements CommandExecutor, TabCompleter {
 
-	private static final List<String> tabCompletes = Arrays.asList("reload");
+	private static final List<String> tabCompletes = Arrays.asList("reload", "reroll_all_resources");
 
 	public List<String> onTabComplete(CommandSender sender, Command command, String alias, String[] args) {
 		if (args.length == 1)
@@ -83,12 +80,12 @@ public class TownyResourcesAdminCommand implements CommandExecutor, TabCompleter
 		}
 		TownyResourcesMessagingUtil.sendErrorMsg(sender, TownyResourcesTranslation.of("townyresources_failed_to_reload"));
 	}
-	
+
 	private void parseReRollCommand(CommandSender sender) {
 		TownyMessaging.sendMessage(sender, TownyResourcesTranslation.of("msg_confirm_reroll"));
 		Confirmation.runOnAccept(() -> {
 			TownResourceDiscoveryController.reRollAllExistingResources();
-			TownyResourcesMessagingUtil.sendGlobalMessage(TownyResourcesTranslation.of("all_resources_rerolled"));			
+			TownyResourcesMessagingUtil.sendGlobalMessage(TownyResourcesTranslation.of("all_resources_rerolled"));
 		})
 		.sendTo(sender);
 	}

--- a/src/main/java/io/github/townyadvanced/townyresources/controllers/TownResourceDiscoveryController.java
+++ b/src/main/java/io/github/townyadvanced/townyresources/controllers/TownResourceDiscoveryController.java
@@ -45,12 +45,15 @@ public class TownResourceDiscoveryController {
         }
 
         //Ensure the player can afford this survey
-        if (TownyEconomyHandler.isActive() && !resident.getAccount().canPayFromHoldings(surveyCost))
-			throw new TownyException(TownyResourcesTranslation.of("msg_err_survey_too_expensive",
-                TownyEconomyHandler.getFormattedBalance(surveyCost), resident.getAccount().getHoldingFormattedBalance()));
+        if (TownyEconomyHandler.isActive()) {
+            if(!resident.getAccount().canPayFromHoldings(surveyCost)) {
+			    throw new TownyException(TownyResourcesTranslation.of("msg_err_survey_too_expensive",
+                    TownyEconomyHandler.getFormattedBalance(surveyCost), resident.getAccount().getHoldingFormattedBalance()));
+            }
 
-		//Pay for the survey
-		resident.getAccount().withdraw(surveyCost, "Cost of resources survey.");
+            //Pay for the survey
+            resident.getAccount().withdraw(surveyCost, "Cost of resources survey.");
+        }
 
         //Calculate a new category and material for discovery
         List<String> discoveredMaterials = new ArrayList<>(alreadyDiscoveredMaterials);

--- a/src/main/java/io/github/townyadvanced/townyresources/controllers/TownResourceDiscoveryController.java
+++ b/src/main/java/io/github/townyadvanced/townyresources/controllers/TownResourceDiscoveryController.java
@@ -70,10 +70,10 @@ public class TownResourceDiscoveryController {
         } else if (town.hasNation()) {
             TownResourceProductionController.recalculateProductionForOneNation(town.getNation());
         }
-        
+
          //Send global message
-   		int levelOfNewResource = discoveredMaterials.size();
-   		double productivityModifierNormalized = (double)TownyResourcesSettings.getProductionPercentagesPerResourceLevel().get(levelOfNewResource-1) / 100;
+        int levelOfNewResource = discoveredMaterials.size();
+        double productivityModifierNormalized = (double)TownyResourcesSettings.getProductionPercentagesPerResourceLevel().get(levelOfNewResource-1) / 100;
         int preTaxProduction = (int)((winningCategory.getBaseAmountItems() * productivityModifierNormalized) + 0.5); 
         String categoryName = TownyResourcesMessagingUtil.formatOfferCategoryNameForDisplay(winningCategory);
         String materialName = TownyResourcesMessagingUtil.formatMaterialNameForDisplay(winningMaterial);
@@ -124,7 +124,7 @@ public class TownResourceDiscoveryController {
         return winningCategory;
     }
 
-    private static String calculateWinningMaterial(ResourceOfferCategory winningCategory) {                
+    private static String calculateWinningMaterial(ResourceOfferCategory winningCategory) {
         //Determine the winning material
         int winningNumber = (int)((Math.random() * winningCategory.getMaterialsInCategory().size()));
         String winningMaterial = winningCategory.getMaterialsInCategory().get(winningNumber);
@@ -145,18 +145,18 @@ public class TownResourceDiscoveryController {
                     for(int i = 0; i < numTownResources; i++) {
                         resourceOfferCategory = calculateWinningCategory(discoveredTownResources);
                         resourceOfferMaterial = calculateWinningMaterial(resourceOfferCategory);
-                        discoveredTownResources.add(resourceOfferMaterial);    
+                        discoveredTownResources.add(resourceOfferMaterial);
                     }
                 } catch (Exception ignored) {
                     //An exception may occur if the offers list is too small for a discovery.
                     //But we assume that is intended and do not throw.
-                }                 
+                }
                 //Set the new list of town resources
                 TownyResourcesGovernmentMetaDataController.setDiscovered(town, discoveredTownResources);
                 //Save town
-                town.save();                
-            } 
-        }            
+                town.save();
+            }
+        }
         //Now recalculate production for all towns & nations
         TownResourceProductionController.recalculateAllProduction();
     }

--- a/src/main/java/io/github/townyadvanced/townyresources/controllers/TownResourceDiscoveryController.java
+++ b/src/main/java/io/github/townyadvanced/townyresources/controllers/TownResourceDiscoveryController.java
@@ -2,6 +2,7 @@ package io.github.townyadvanced.townyresources.controllers;
 
 import com.gmail.goosius.siegewar.TownOccupationController;
 import com.palmergames.bukkit.towny.TownyEconomyHandler;
+import com.palmergames.bukkit.towny.TownyUniverse;
 import com.palmergames.bukkit.towny.exceptions.TownyException;
 import com.palmergames.bukkit.towny.object.Resident;
 import com.palmergames.bukkit.towny.object.Town;
@@ -11,7 +12,6 @@ import io.github.townyadvanced.townyresources.objects.ResourceOfferCategory;
 import io.github.townyadvanced.townyresources.settings.TownyResourcesSettings;
 import io.github.townyadvanced.townyresources.settings.TownyResourcesTranslation;
 import io.github.townyadvanced.townyresources.util.TownyResourcesMessagingUtil;
-import org.bukkit.Material;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -49,6 +49,38 @@ public class TownResourceDiscoveryController {
 			throw new TownyException(TownyResourcesTranslation.of("msg_err_survey_too_expensive",
                 TownyEconomyHandler.getFormattedBalance(surveyCost), resident.getAccount().getHoldingFormattedBalance()));
 
+		//Pay for the survey
+		resident.getAccount().withdraw(surveyCost, "Cost of resources survey.");
+
+        //Calculate a new category and material for discovery
+        List<String> discoveredMaterials = new ArrayList<>(alreadyDiscoveredMaterials);
+        ResourceOfferCategory winningCategory = calculateWinningCategory(discoveredMaterials);
+        String winningMaterial = calculateWinningMaterial(winningCategory);
+        //Discover the resource
+        discoveredMaterials.add(winningMaterial);
+        TownyResourcesGovernmentMetaDataController.setDiscovered(town, discoveredMaterials);
+        town.save();
+
+        //Recalculate Town Production
+        TownResourceProductionController.recalculateProductionForOneTown(town);
+
+        //Recalculate Nation Production
+        if(TownyResources.getPlugin().isSiegeWarInstalled() && TownOccupationController.isTownOccupied(town)) {
+            TownResourceProductionController.recalculateProductionForOneNation(TownOccupationController.getTownOccupier(town));
+        } else if (town.hasNation()) {
+            TownResourceProductionController.recalculateProductionForOneNation(town.getNation());
+        }
+        
+         //Send global message
+   		int levelOfNewResource = discoveredMaterials.size();
+   		double productivityModifierNormalized = (double)TownyResourcesSettings.getProductionPercentagesPerResourceLevel().get(levelOfNewResource-1) / 100;
+        int preTaxProduction = (int)((winningCategory.getBaseAmountItems() * productivityModifierNormalized) + 0.5); 
+        String categoryName = TownyResourcesMessagingUtil.formatOfferCategoryNameForDisplay(winningCategory);
+        String materialName = TownyResourcesMessagingUtil.formatMaterialNameForDisplay(winningMaterial);
+		TownyResourcesMessagingUtil.sendGlobalMessage(TownyResourcesTranslation.of("discovery.success", resident.getName(), categoryName, town.getName(), preTaxProduction, materialName));
+    }
+
+    private static ResourceOfferCategory calculateWinningCategory(List<String> alreadyDiscoveredMaterials) throws TownyException{
  		/*
  		 * Generate a list of candidate categories
  		 * This list will be comprised of all resource offer categories, except those of already discovered materials
@@ -88,36 +120,44 @@ public class TownResourceDiscoveryController {
                 break;
             }
         }
-        
+
+        return winningCategory;
+    }
+
+    private static String calculateWinningMaterial(ResourceOfferCategory winningCategory) {                
         //Determine the winning material
-        winningNumber = (int)((Math.random() * winningCategory.getMaterialsInCategory().size()));
+        int winningNumber = (int)((Math.random() * winningCategory.getMaterialsInCategory().size()));
         String winningMaterial = winningCategory.getMaterialsInCategory().get(winningNumber);
+        return winningMaterial;
+    }
 
-		//Pay for the survey
-		resident.getAccount().withdraw(surveyCost, "Cost of resources survey.");
-
-        //Discover the resource
-        List<String> discoveredMaterials = new ArrayList<>(alreadyDiscoveredMaterials);
-        discoveredMaterials.add(winningMaterial);
-        TownyResourcesGovernmentMetaDataController.setDiscovered(town, discoveredMaterials);
-        town.save();
-
-        //Recalculate Town Production
-        TownResourceProductionController.recalculateProductionForOneTown(town);
-
-        //Recalculate Nation Production
-        if(TownyResources.getPlugin().isSiegeWarInstalled() && TownOccupationController.isTownOccupied(town)) {
-            TownResourceProductionController.recalculateProductionForOneNation(TownOccupationController.getTownOccupier(town));
-        } else if (town.hasNation()) {
-            TownResourceProductionController.recalculateProductionForOneNation(town.getNation());
-        }
-        
-         //Send global message
-   		int levelOfNewResource = discoveredMaterials.size();
-   		double productivityModifierNormalized = (double)TownyResourcesSettings.getProductionPercentagesPerResourceLevel().get(levelOfNewResource-1) / 100;
-        int preTaxProduction = (int)((winningCategory.getBaseAmountItems() * productivityModifierNormalized) + 0.5); 
-        String categoryName = TownyResourcesMessagingUtil.formatOfferCategoryNameForDisplay(winningCategory);
-        String materialName = TownyResourcesMessagingUtil.formatMaterialNameForDisplay(winningMaterial);
-		TownyResourcesMessagingUtil.sendGlobalMessage(TownyResourcesTranslation.of("discovery.success", resident.getName(), categoryName, town.getName(), preTaxProduction, materialName));
+    public static void reRollAllExistingResources() {
+        int numTownResources;
+        List<String> discoveredTownResources;
+        ResourceOfferCategory resourceOfferCategory;
+        String resourceOfferMaterial;
+        for(Town town: TownyUniverse.getInstance().getTowns()) {
+            numTownResources = TownyResourcesGovernmentMetaDataController.getDiscoveredAsList(town).size();
+            discoveredTownResources = new ArrayList<>();
+            if(numTownResources > 0) {
+                try {
+                    //ReRoll all resources of the town
+                    for(int i = 0; i < numTownResources; i++) {
+                        resourceOfferCategory = calculateWinningCategory(discoveredTownResources);
+                        resourceOfferMaterial = calculateWinningMaterial(resourceOfferCategory);
+                        discoveredTownResources.add(resourceOfferMaterial);    
+                    }
+                } catch (Exception ignored) {
+                    //An exception may occur if the offers list is too small for a discovery.
+                    //But we assume that is intended and do not throw.
+                }                 
+                //Set the new list of town resources
+                TownyResourcesGovernmentMetaDataController.setDiscovered(town, discoveredTownResources);
+                //Save town
+                town.save();                
+            } 
+        }            
+        //Now recalculate production for all towns & nations
+        TownResourceProductionController.recalculateAllProduction();
     }
 }

--- a/src/main/resources/chinese.yml
+++ b/src/main/resources/chinese.yml
@@ -1,5 +1,5 @@
 name: TownyResources
-version: 0.05
+version: 0.06
 language: chinese
 author: Nailm
 website: 'https://github.com/TownyAdvanced/TownyResources'
@@ -152,3 +152,8 @@ msg_err_cannot_collect_unknown_material: "Cannot collect the following unknown m
 
 #Added in 0.05
 msg_confirm_survey_town_level_warning: "&cWARNING: Although the resource can be discovered, the town does not have a large enough population to produce it. Required Town Level: %d, Actual Town Level %d."
+
+#Added in 0.06
+admin_help_reroll: "Reroll all currently discovered resources."
+msg_confirm_reroll: "&cWARNING: You are about to re-roll all discovered town resources. This will affect all towns which have already discovered resources."
+all_resources_rerolled: "All discovered town resources have been rerolled"

--- a/src/main/resources/english.yml
+++ b/src/main/resources/english.yml
@@ -1,5 +1,5 @@
 name: TownyResources
-version: 0.05
+version: 0.06
 language: english
 author: Goosius
 website: 'https://github.com/TownyAdvanced/TownyResources'
@@ -152,3 +152,8 @@ msg_err_cannot_collect_unknown_material: "Cannot collect the following unknown m
 
 #Added in 0.05
 msg_confirm_survey_town_level_warning: "&cWARNING: Although the resource can be discovered, the town does not have a large enough population to produce it. Required Town Level: %d, Actual Town Level %d."
+
+#Added in 0.06
+admin_help_reroll: "Reroll all currently discovered resources."
+msg_confirm_reroll: "&cWARNING: You are about to re-roll all discovered town resources. This will affect all towns which have already discovered resources."
+all_resources_rerolled: "All discovered town resources have been rerolled"


### PR DESCRIPTION
###DESCRIPTION
- Adds a new admin command called "reroll_all_resources"
- This command rerolls all disovered town resources
- Useful if, after multiple surveys have been done, an admin realizes that they forgot to include an important offer, or really screwed up the discovery weights.

###CLOSES
Closes #29 

[x] I have tested this pull request for defects on a server.
By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the SiegeWar License for perpetuity.