### PR TITLE
Fix dispensers not shearing mobs when extraction limits are disabled

### DIFF
--- a/src/main/java/io/github/townyadvanced/townyresources/listeners/TownyResourcesBukkitEventListener.java
+++ b/src/main/java/io/github/townyadvanced/townyresources/listeners/TownyResourcesBukkitEventListener.java
@@ -54,7 +54,7 @@ public class TownyResourcesBukkitEventListener implements Listener {
 	
 	@EventHandler()
 	public void onBlockShearEntityEvent(BlockShearEntityEvent event) {
-		if(TownyResourcesSettings.isEnabled() && !event.isCancelled()) {
+		if(TownyResourcesSettings.isEnabled() && TownyResourcesSettings.areResourceExtractionLimitsEnabled() && !event.isCancelled()) {
 			//Dispensers cannot shear entities
 			event.setCancelled(true);
 		}	


### PR DESCRIPTION
This PR fixes dispensers not shearing mobs even when extraction limits are disabled by only cancelling `BlockShearEntityEvent` if they are enabled.