### PR TITLE
Tr 44 - Fix slimefun-related loading error

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.github.townyadvanced</groupId>
   <artifactId>TownyResources</artifactId>
-  <version>0.1.1</version>
+  <version>0.1.2</version>
   <name>townyresources</name> <!-- Leave lower-cased -->
 
   <properties>
@@ -54,7 +54,7 @@
     <dependency>
       <groupId>com.github.TheBusyBiscuit</groupId>
       <artifactId>Slimefun4</artifactId>
-      <version>RC-15</version>
+      <version>RC-27</version>
       <scope>provided</scope>
     </dependency>
   </dependencies>

--- a/src/main/java/io/github/townyadvanced/townyresources/controllers/TownResourceCollectionController.java
+++ b/src/main/java/io/github/townyadvanced/townyresources/controllers/TownResourceCollectionController.java
@@ -4,12 +4,11 @@ import com.palmergames.bukkit.towny.Towny;
 import com.palmergames.bukkit.towny.object.Government;
 import com.palmergames.bukkit.towny.object.Nation;
 import com.palmergames.bukkit.towny.object.Town;
-import io.github.thebusybiscuit.slimefun4.implementation.SlimefunItems;
+import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
 import io.github.townyadvanced.townyresources.TownyResources;
 import io.github.townyadvanced.townyresources.metadata.TownyResourcesGovernmentMetaDataController;
 import io.github.townyadvanced.townyresources.settings.TownyResourcesTranslation;
 import io.github.townyadvanced.townyresources.util.TownyResourcesMessagingUtil;
-import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.SlimefunItem;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
@@ -71,7 +70,7 @@ public class TownResourceCollectionController {
             
             //Try creating a slimefun itemstack
             if(TownyResources.getPlugin().isSlimeFunInstalled()) {
-                SlimefunItem slimeFunItem = SlimefunItem.getByID(materialName);
+                SlimefunItem slimeFunItem = SlimefunItem.getById(materialName);
                 if(slimeFunItem != null) {
                     itemStack = slimeFunItem.getRecipeOutput();
                     itemStack.setAmount(amount);

--- a/src/main/java/io/github/townyadvanced/townyresources/settings/TownyResourcesSettings.java
+++ b/src/main/java/io/github/townyadvanced/townyresources/settings/TownyResourcesSettings.java
@@ -237,7 +237,7 @@ public class TownyResourcesSettings {
 		if(material != null)
 			return true;  	//Known material
 		if(TownyResources.getPlugin().isSlimeFunInstalled()) {
-		   	SlimefunItem slimeFunItem = SlimefunItem.getById(materialName);
+			SlimefunItem slimeFunItem = SlimefunItem.getById(materialName);
 			if(slimeFunItem != null)
 				return true;  //Known material 
 		}

--- a/src/main/java/io/github/townyadvanced/townyresources/settings/TownyResourcesSettings.java
+++ b/src/main/java/io/github/townyadvanced/townyresources/settings/TownyResourcesSettings.java
@@ -6,14 +6,13 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import com.palmergames.bukkit.towny.exceptions.TownyException;
+import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
 import io.github.townyadvanced.townyresources.TownyResources;
 import io.github.townyadvanced.townyresources.objects.ResourceExtractionCategory;
 import io.github.townyadvanced.townyresources.objects.ResourceOffer;
 import io.github.townyadvanced.townyresources.objects.ResourceOfferCategory;
 import io.github.townyadvanced.townyresources.util.FileMgmt;
-import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.SlimefunItem;
 import org.bukkit.Material;
-import org.bukkit.inventory.ItemStack;
 
 public class TownyResourcesSettings {
 	private static CommentedConfiguration config, newConfig;
@@ -238,7 +237,7 @@ public class TownyResourcesSettings {
 		if(material != null)
 			return true;  	//Known material
 		if(TownyResources.getPlugin().isSlimeFunInstalled()) {
-		   	SlimefunItem slimeFunItem = SlimefunItem.getByID(materialName);
+		   	SlimefunItem slimeFunItem = SlimefunItem.getById(materialName);
 			if(slimeFunItem != null)
 				return true;  //Known material 
 		}

--- a/src/main/java/io/github/townyadvanced/townyresources/util/TownyResourcesMessagingUtil.java
+++ b/src/main/java/io/github/townyadvanced/townyresources/util/TownyResourcesMessagingUtil.java
@@ -1,10 +1,10 @@
 package io.github.townyadvanced.townyresources.util;
 
 import com.meowj.langutils.lang.LanguageHelper;
+import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
 import io.github.townyadvanced.townyresources.objects.ResourceExtractionCategory;
 import io.github.townyadvanced.townyresources.objects.ResourceOfferCategory;
 import io.github.townyadvanced.townyresources.settings.TownyResourcesSettings;
-import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.SlimefunItem;
 import org.apache.commons.lang.WordUtils;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
@@ -137,7 +137,7 @@ public class TownyResourcesMessagingUtil {
         Material material = Material.getMaterial(materialName);
         if(material == null) {
             if(TownyResources.getPlugin().isSlimeFunInstalled()) {
-                SlimefunItem slimefunItem = SlimefunItem.getByID(materialName);
+                SlimefunItem slimefunItem = SlimefunItem.getById(materialName);
                 if(slimefunItem != null) {
                     return slimefunItem.getItemName().replaceAll("[^\\w\\s]\\w","");
                 }                


### PR DESCRIPTION
### DESCRIPTION
- TR is not loading on servers with the latest slimefun
- This is because TR is using quite an old import, and slimefun changed their code since then
- This PR fixes the issue

### CLOSES
Closes #44 

[x] I have tested this pull request for defects on a server.
By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the TownyResources License for perpetuity.