### PR TITLE
FR 67 - Add additional daily resource limit toggles

### DIFF
--- a/src/main/java/io/github/townyadvanced/townyresources/controllers/PlayerExtractionLimitsController.java
+++ b/src/main/java/io/github/townyadvanced/townyresources/controllers/PlayerExtractionLimitsController.java
@@ -261,9 +261,6 @@ public class PlayerExtractionLimitsController {
         if(true)
             return;
 
-        if(!TownyResourcesSettings.areDropsExtractionLimitsEnabled())
-            return;
-
         //Return if item is not an egg
         Material itemMaterial = event.getEntity().getItemStack().getType();        
         if(itemMaterial != Material.EGG)

--- a/src/main/java/io/github/townyadvanced/townyresources/controllers/PlayerExtractionLimitsController.java
+++ b/src/main/java/io/github/townyadvanced/townyresources/controllers/PlayerExtractionLimitsController.java
@@ -80,7 +80,7 @@ public class PlayerExtractionLimitsController {
     public static void processEntityDamageByEntityEvent(EntityDamageByEntityEvent event) {
         if(!TownyResourcesSettings.areResourceExtractionLimitsEnabled() || !TownyResourcesSettings.areDropsExtractionLimitsEnabled())
             return;
-
+    
         //Return if not a mob
         if(!(event.getEntity() instanceof Mob))
             return;

--- a/src/main/java/io/github/townyadvanced/townyresources/controllers/PlayerExtractionLimitsController.java
+++ b/src/main/java/io/github/townyadvanced/townyresources/controllers/PlayerExtractionLimitsController.java
@@ -80,9 +80,11 @@ public class PlayerExtractionLimitsController {
     public static void processEntityDamageByEntityEvent(EntityDamageByEntityEvent event) {
         if(!TownyResourcesSettings.areResourceExtractionLimitsEnabled() || !TownyResourcesSettings.areDropsExtractionLimitsEnabled())
             return;
+
         //Return if not a mob
         if(!(event.getEntity() instanceof Mob))
             return;
+
         if(event.getDamager() instanceof Player) {
             //Mark the mob as recently hit by the player
             mobsDamagedByPlayersThisShortTick.put(event.getEntity(), event.getDamager());                

--- a/src/main/java/io/github/townyadvanced/townyresources/controllers/PlayerExtractionLimitsController.java
+++ b/src/main/java/io/github/townyadvanced/townyresources/controllers/PlayerExtractionLimitsController.java
@@ -78,9 +78,9 @@ public class PlayerExtractionLimitsController {
      * @param event the event
      */
     public static void processEntityDamageByEntityEvent(EntityDamageByEntityEvent event) {
-        if(!TownyResourcesSettings.areResourceExtractionLimitsEnabled())
+        if(!TownyResourcesSettings.areResourceExtractionLimitsEnabled() || !TownyResourcesSettings.areDropsExtractionLimitsEnabled())
             return;
-    
+
         //Return if not a mob
         if(!(event.getEntity() instanceof Mob))
             return;
@@ -101,9 +101,8 @@ public class PlayerExtractionLimitsController {
      * @param event the event
      */
     public static void processEntityDeathEvent(EntityDeathEvent event) {
-        if(!TownyResourcesSettings.areResourceExtractionLimitsEnabled())
+        if(!TownyResourcesSettings.areResourceExtractionLimitsEnabled() || !TownyResourcesSettings.areDropsExtractionLimitsEnabled())
             return;
-
         if(event.getEntity() instanceof Mob) {
             //If the mob was not recently hit by a player, it drops nothing
             if (!mobsDamagedByPlayersThisShortTick.containsKey(event.getEntity())
@@ -157,6 +156,9 @@ public class PlayerExtractionLimitsController {
      * @param event the event - this event is only called for Players (not entities)
      */
     public static void processBlockBreakEvent(BlockBreakEvent event) {
+        if(!TownyResourcesSettings.areResourceExtractionLimitsEnabled() || !TownyResourcesSettings.areBlocksExtractionLimitsEnabled())
+            return;
+
         if(isPlayerNotExtractLimited(event.getPlayer()))
             return;
 
@@ -259,7 +261,7 @@ public class PlayerExtractionLimitsController {
         if(true)
             return;
 
-        if(!TownyResourcesSettings.areResourceExtractionLimitsEnabled())
+        if(!TownyResourcesSettings.areDropsExtractionLimitsEnabled())
             return;
 
         //Return if item is not an egg
@@ -313,6 +315,9 @@ public class PlayerExtractionLimitsController {
      * @param event event
      */
     public static void processPlayerFishEvent(PlayerFishEvent event) {
+        if(!TownyResourcesSettings.areResourceExtractionLimitsEnabled() || !TownyResourcesSettings.areFishingExtractionLimitsEnabled())
+            return;
+
         if(isPlayerNotExtractLimited(event.getPlayer()))
             return;
 

--- a/src/main/java/io/github/townyadvanced/townyresources/controllers/PlayerExtractionLimitsController.java
+++ b/src/main/java/io/github/townyadvanced/townyresources/controllers/PlayerExtractionLimitsController.java
@@ -80,11 +80,9 @@ public class PlayerExtractionLimitsController {
     public static void processEntityDamageByEntityEvent(EntityDamageByEntityEvent event) {
         if(!TownyResourcesSettings.areResourceExtractionLimitsEnabled() || !TownyResourcesSettings.areDropsExtractionLimitsEnabled())
             return;
-
         //Return if not a mob
         if(!(event.getEntity() instanceof Mob))
             return;
-
         if(event.getDamager() instanceof Player) {
             //Mark the mob as recently hit by the player
             mobsDamagedByPlayersThisShortTick.put(event.getEntity(), event.getDamager());                

--- a/src/main/java/io/github/townyadvanced/townyresources/controllers/PlayerExtractionLimitsController.java
+++ b/src/main/java/io/github/townyadvanced/townyresources/controllers/PlayerExtractionLimitsController.java
@@ -84,7 +84,7 @@ public class PlayerExtractionLimitsController {
         //Return if not a mob
         if(!(event.getEntity() instanceof Mob))
             return;
-                
+
         if(event.getDamager() instanceof Player) {
             //Mark the mob as recently hit by the player
             mobsDamagedByPlayersThisShortTick.put(event.getEntity(), event.getDamager());                
@@ -103,6 +103,7 @@ public class PlayerExtractionLimitsController {
     public static void processEntityDeathEvent(EntityDeathEvent event) {
         if(!TownyResourcesSettings.areResourceExtractionLimitsEnabled() || !TownyResourcesSettings.areDropsExtractionLimitsEnabled())
             return;
+
         if(event.getEntity() instanceof Mob) {
             //If the mob was not recently hit by a player, it drops nothing
             if (!mobsDamagedByPlayersThisShortTick.containsKey(event.getEntity())

--- a/src/main/java/io/github/townyadvanced/townyresources/controllers/PlayerExtractionLimitsController.java
+++ b/src/main/java/io/github/townyadvanced/townyresources/controllers/PlayerExtractionLimitsController.java
@@ -84,7 +84,7 @@ public class PlayerExtractionLimitsController {
         //Return if not a mob
         if(!(event.getEntity() instanceof Mob))
             return;
-
+                
         if(event.getDamager() instanceof Player) {
             //Mark the mob as recently hit by the player
             mobsDamagedByPlayersThisShortTick.put(event.getEntity(), event.getDamager());                

--- a/src/main/java/io/github/townyadvanced/townyresources/listeners/TownyResourcesBukkitEventListener.java
+++ b/src/main/java/io/github/townyadvanced/townyresources/listeners/TownyResourcesBukkitEventListener.java
@@ -44,7 +44,7 @@ public class TownyResourcesBukkitEventListener implements Listener {
 	
 	@EventHandler(ignoreCancelled = true)
 	public void onBlockShearEntityEvent(BlockShearEntityEvent event) {
-		if(TownyResourcesSettings.isEnabled() && TownyResourcesSettings.areResourceExtractionLimitsEnabled()) {
+		if(TownyResourcesSettings.isEnabled() && TownyResourcesSettings.areResourceExtractionLimitsEnabled() && TownyResourcesSettings.areShearingExtractionLimitsEnabled()) {
 			//Dispensers cannot shear entities
 			event.setCancelled(true);
 		}	
@@ -52,7 +52,7 @@ public class TownyResourcesBukkitEventListener implements Listener {
 	
 	@EventHandler(ignoreCancelled = true)
 	public void onPlayerShearEntityEvent(PlayerShearEntityEvent event) {
-		if(TownyResourcesSettings.isEnabled()) {
+		if(TownyResourcesSettings.isEnabled() && TownyResourcesSettings.areShearingExtractionLimitsEnabled()) {
 			PlayerExtractionLimitsController.processPlayerShearEntityEvent(event);
 		}	
 	}

--- a/src/main/java/io/github/townyadvanced/townyresources/listeners/TownyResourcesBukkitEventListener.java
+++ b/src/main/java/io/github/townyadvanced/townyresources/listeners/TownyResourcesBukkitEventListener.java
@@ -52,7 +52,7 @@ public class TownyResourcesBukkitEventListener implements Listener {
 	
 	@EventHandler(ignoreCancelled = true)
 	public void onPlayerShearEntityEvent(PlayerShearEntityEvent event) {
-		if(TownyResourcesSettings.isEnabled() && TownyResourcesSettings.areShearingExtractionLimitsEnabled()) {
+		if(TownyResourcesSettings.isEnabled() && TownyResourcesSettings.areResourceExtractionLimitsEnabled() && TownyResourcesSettings.areShearingExtractionLimitsEnabled()) {
 			PlayerExtractionLimitsController.processPlayerShearEntityEvent(event);
 		}	
 	}

--- a/src/main/java/io/github/townyadvanced/townyresources/settings/TownyResourcesConfigNodes.java
+++ b/src/main/java/io/github/townyadvanced/townyresources/settings/TownyResourcesConfigNodes.java
@@ -34,6 +34,36 @@ public enum TownyResourcesConfigNodes {
 			"",
 			"# If true, then daily player resource extraction limits are enabled.",
 			"# If false, then daily player resource extraction limits are disabled."),
+	RESOURCE_EXTRACTION_LIMITS_TOGGLES(
+			"resource_extraction_limits.toggles",
+			"",
+			"",
+			"# Individual toggles for daily resource extraction limits.",
+			"# All of these toggles will disable if the above is set to false."),
+	RESOURCE_EXTRACTION_LIMITS_BLOCKS(
+			"resource_extraction_limits.toggles.blocks",
+			"true",
+			"",
+			"# If true, then daily player resource extraction limits for mining blocks are enabled.",
+			"# If false, then daily player resource extraction limits for mining blocks are disabled."),
+	RESOURCE_EXTRACTION_LIMITS_DROPS(
+			"resource_extraction_limits.toggles.drops",
+			"true",
+			"",
+			"# If true, then daily player resource extraction limits that apply to entity drops are enabled. When enabled, players must interact with an entity on death to receive item drops.",
+			"# If false, then daily player resource extraction limits that apply to entity drops are disabled. When disabled, automatic entity killing farms will function."),
+	RESOURCE_EXTRACTION_LIMITS_SHEARING(
+			"resource_extraction_limits.toggles.shearing",
+			"true",
+			"",
+			"# If true, then daily player resource extraction limits for sheep shearing are enabled.",
+			"# If false, then daily player resource extraction limits for sheep shearing are disabled. When disabled, automatic redstone farms will function."),
+	RESOURCE_EXTRACTION_LIMITS_FISHING(
+			"resource_extraction_limits.toggles.fishing",
+			"true",
+			"",
+			"# If true, then daily player resource extraction limits for fishing are enabled.",
+			"# If false, then daily player resource extraction limits for fishing are disabled."),
 	RESOURCE_EXTRACTION_LIMITS_COOLDOWN_AFTER_DAILY_LIMIT_WARNING_MESSAGE_MILLIS(
 			"resource_extraction_limits.cooldown_after_daily_limit_warning_message_millis",
 			"5000",

--- a/src/main/java/io/github/townyadvanced/townyresources/settings/TownyResourcesSettings.java
+++ b/src/main/java/io/github/townyadvanced/townyresources/settings/TownyResourcesSettings.java
@@ -352,6 +352,22 @@ public class TownyResourcesSettings {
 		return getBoolean(TownyResourcesConfigNodes.RESOURCE_EXTRACTION_LIMITS_ENABLED);
 	}
 
+	public static boolean areBlocksExtractionLimitsEnabled() {
+		return getBoolean(TownyResourcesConfigNodes.RESOURCE_EXTRACTION_LIMITS_BLOCKS);
+	}
+
+	public static boolean areDropsExtractionLimitsEnabled() {
+		return getBoolean(TownyResourcesConfigNodes.RESOURCE_EXTRACTION_LIMITS_DROPS);
+	}
+
+	public static boolean areShearingExtractionLimitsEnabled() {
+		return getBoolean(TownyResourcesConfigNodes.RESOURCE_EXTRACTION_LIMITS_SHEARING);
+	}
+
+	public static boolean areFishingExtractionLimitsEnabled() {
+		return getBoolean(TownyResourcesConfigNodes.RESOURCE_EXTRACTION_LIMITS_FISHING);
+	}
+
 	public static int getCooldownAfterDailyLimitWarningMessageMillis() {
 		return getInt(TownyResourcesConfigNodes.RESOURCE_EXTRACTION_LIMITS_COOLDOWN_AFTER_DAILY_LIMIT_WARNING_MESSAGE_MILLIS);
 	}


### PR DESCRIPTION
### Description

Adds additional toggable settings for daily extraction limits.
- blocks (enables/disables daily resource extraction limits for block related checks)
- drops (enables/disables daily resource extraction limits for entity drop related checks)
- shearing (enables/disables daily resource extraction limits for shearing related checks)
- fishing (enables/disables daily resource extraction limits for fishing related checks)

### Resolves
Closes #67 