### PR TITLE
Fix MythicMobs imported item names not displaying correctly

### DIFF
--- a/src/main/java/io/github/townyadvanced/townyresources/util/TownyResourcesMessagingUtil.java
+++ b/src/main/java/io/github/townyadvanced/townyresources/util/TownyResourcesMessagingUtil.java
@@ -143,8 +143,18 @@ public class TownyResourcesMessagingUtil {
                 if(maybeMythicItem.isPresent()) {
                     MythicItem mythicItem = maybeMythicItem.get();
                     String maybeDisplayName = mythicItem.getDisplayName();
-                    if (maybeDisplayName != null)
-                        return maybeDisplayName.replaceAll("[^\\w\\s]\\w","");
+                    if (maybeDisplayName != null) {
+                        return maybeDisplayName.replaceAll("[^\\w\\s]\\w", "");
+                    } else {
+                        // MythicItem#getDisplayName() will always return null for imported items
+                        // try to extract the name from the raw config data
+                        if (mythicItem.getConfig().isSet("ItemStack")) {
+                            ItemStack is = mythicItem.getConfig().getItemStack("ItemStack", (String) null);
+                            if (is != null && is.hasItemMeta() && is.getItemMeta().hasDisplayName()) {
+                                return is.getItemMeta().getDisplayName();
+                            }
+                        }
+                    }
                 }
             }
         } else {


### PR DESCRIPTION
MythicItem#getDisplayName() will always return null for imported items
if #getDisplayName() returns null, attempt to extract the value from the items config data