### PR TITLE
Patch for mm break

### DIFF
--- a/src/main/java/io/github/townyadvanced/townyresources/TownyResources.java
+++ b/src/main/java/io/github/townyadvanced/townyresources/TownyResources.java
@@ -207,6 +207,7 @@ public class TownyResources extends JavaPlugin {
 				mythicMobsInstalled = true;
 				info("  Mythic Mobs Integration Enabled");
 			} catch (Throwable t) {
+                                mythicMobsInstalled = false;
 			        t.printStackTrace();
 				severe( "Problem enabling mythic mobs");
 			}

--- a/src/main/java/io/github/townyadvanced/townyresources/TownyResources.java
+++ b/src/main/java/io/github/townyadvanced/townyresources/TownyResources.java
@@ -168,7 +168,7 @@ public class TownyResources extends JavaPlugin {
 	}
 
 	public boolean isMythicMobsInstalled() { return mythicMobsInstalled; }
-	
+
 	public ItemManager getMythicItemManager() {
 		Plugin mythicMobs = Bukkit.getPluginManager().getPlugin("MythicMobs");
 		return mythicMobsInstalled ? ((MythicMobs) mythicMobs).getItemManager() : null;
@@ -210,7 +210,7 @@ public class TownyResources extends JavaPlugin {
 				e.printStackTrace();
 				severe( "Problem enabling mythic mobs");
 			}
-		} 
+		}
 
 		Plugin languageUtils = Bukkit.getPluginManager().getPlugin("LangUtils");
 		languageUtilsInstalled = languageUtils != null;

--- a/src/main/java/io/github/townyadvanced/townyresources/TownyResources.java
+++ b/src/main/java/io/github/townyadvanced/townyresources/TownyResources.java
@@ -207,7 +207,7 @@ public class TownyResources extends JavaPlugin {
 				mythicMobsInstalled = true;
 				info("  Mythic Mobs Integration Enabled");
 			} catch (Throwable t) {
-				e.printStackTrace();
+			        t.printStackTrace();
 				severe( "Problem enabling mythic mobs");
 			}
 		}

--- a/src/main/java/io/github/townyadvanced/townyresources/TownyResources.java
+++ b/src/main/java/io/github/townyadvanced/townyresources/TownyResources.java
@@ -168,6 +168,7 @@ public class TownyResources extends JavaPlugin {
 	}
 
 	public boolean isMythicMobsInstalled() { return mythicMobsInstalled; }
+	
 	public ItemManager getMythicItemManager() {
 		Plugin mythicMobs = Bukkit.getPluginManager().getPlugin("MythicMobs");
 		return mythicMobsInstalled ? ((MythicMobs) mythicMobs).getItemManager() : null;
@@ -200,10 +201,17 @@ public class TownyResources extends JavaPlugin {
 			info("  Slimefun Integration Enabled");
 
 		Plugin mythicMobs = Bukkit.getPluginManager().getPlugin("MythicMobs");
-		mythicMobsInstalled = mythicMobs != null;
-		if (mythicMobsInstalled)
-			info("  Mythic Mobs Integration Enabled");
-			
+		if(mythicMobs != null) {
+			try {
+				((MythicMobs) mythicMobs).getItemManager();
+				mythicMobsInstalled = true;
+				info("  Mythic Mobs Integration Enabled");
+			} catch (Exception e) {
+				e.printStackTrace();
+				severe( "Problem enabling mythic mobs");
+			}
+		} 
+
 		Plugin languageUtils = Bukkit.getPluginManager().getPlugin("LangUtils");
 		languageUtilsInstalled = languageUtils != null;
 		if(languageUtilsInstalled) 

--- a/src/main/java/io/github/townyadvanced/townyresources/TownyResources.java
+++ b/src/main/java/io/github/townyadvanced/townyresources/TownyResources.java
@@ -206,7 +206,7 @@ public class TownyResources extends JavaPlugin {
 				((MythicMobs) mythicMobs).getItemManager();
 				mythicMobsInstalled = true;
 				info("  Mythic Mobs Integration Enabled");
-			} catch (Exception e) {
+			} catch (Throwable t) {
 				e.printStackTrace();
 				severe( "Problem enabling mythic mobs");
 			}


### PR DESCRIPTION
- as per title
- note that while the pr will stop TR from crashing while MM, TR won't load unless all MM categories are removed, which the server will be prompted to do.

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the SiegeWar [License](https://github.com/TownyAdvanced/SiegeWar/blob/master/LICENSE.md) for perpetuity.