### PR TITLE
Make StatusScreens better.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.github.townyadvanced</groupId>
   <artifactId>TownyResources</artifactId>
-  <version>0.2.2</version>
+  <version>0.2.3</version>
   <name>townyresources</name> <!-- Leave lower-cased -->
 
   <properties>
@@ -15,6 +15,10 @@
     <repository>
       <id>spigot-repo</id>
       <url>https://hub.spigotmc.org/nexus/content/repositories/snapshots/</url>
+    </repository>
+    <repository>
+      <id>glaremasters repo</id>
+      <url>https://repo.glaremasters.me/repository/towny/</url>
     </repository>
 	<repository>
 	  <id>jitpack.io</id>
@@ -35,14 +39,14 @@
     <dependency>
       <groupId>org.spigotmc</groupId>
       <artifactId>spigot-api</artifactId>
-      <version>1.18.1-R0.1-SNAPSHOT</version>
+      <version>1.19.2-R0.1-SNAPSHOT</version>
       <scope>provided</scope>
     </dependency>
 	<dependency>
-	  <groupId>com.github.TownyAdvanced</groupId>
-	  <artifactId>Towny</artifactId>
-	  <version>0.97.5.0</version>
-	  <scope>provided</scope>
+      <groupId>com.github.TownyAdvanced</groupId>
+      <artifactId>Towny</artifactId>
+      <version>0.98.3.5</version>
+      <scope>provided</scope>
 	</dependency>
     <dependency>
 	  <groupId>com.github.TownyAdvanced</groupId>

--- a/src/main/java/io/github/townyadvanced/townyresources/TownyResources.java
+++ b/src/main/java/io/github/townyadvanced/townyresources/TownyResources.java
@@ -21,7 +21,7 @@ import java.io.File;
 public class TownyResources extends JavaPlugin {
 	
 	private static TownyResources plugin;
-	private static Version requiredTownyVersion = Version.fromString("0.97.5.0");
+	private static Version requiredTownyVersion = Version.fromString("0.98.3.5");
 	private static boolean siegeWarInstalled;
 	private static boolean dynmapTownyInstalled; 
 	private static boolean languageUtilsInstalled;

--- a/src/main/java/io/github/townyadvanced/townyresources/commands/TownyResourcesCommand.java
+++ b/src/main/java/io/github/townyadvanced/townyresources/commands/TownyResourcesCommand.java
@@ -4,7 +4,6 @@ import com.palmergames.bukkit.towny.TownyAPI;
 import com.palmergames.bukkit.towny.TownyEconomyHandler;
 import com.palmergames.bukkit.towny.TownyMessaging;
 import com.palmergames.bukkit.towny.TownyUniverse;
-import com.palmergames.bukkit.towny.TownySettings;
 import com.palmergames.bukkit.towny.confirmations.Confirmation;
 import com.palmergames.bukkit.towny.exceptions.TownyException;
 import com.palmergames.bukkit.towny.object.Nation;
@@ -131,7 +130,7 @@ public class TownyResourcesCommand implements CommandExecutor, TabCompleter {
 
 		//Send warning message if town level is too low
 		int requiredTownLevel = TownyResourcesSettings.getProductionTownLevelRequirementPerResourceLevel().get(indexOfNextResourceLevel);
-		int actualTownLevel = TownySettings.calcTownLevelId(town);
+		int actualTownLevel = town.getLevel();
 		if(actualTownLevel < requiredTownLevel) {
 			TownyMessaging.sendMessage(player, TownyResourcesTranslation.of("msg_confirm_survey_town_level_warning", requiredTownLevel, actualTownLevel));
 		}

--- a/src/main/java/io/github/townyadvanced/townyresources/controllers/TownResourceProductionController.java
+++ b/src/main/java/io/github/townyadvanced/townyresources/controllers/TownResourceProductionController.java
@@ -1,7 +1,6 @@
 package io.github.townyadvanced.townyresources.controllers;
 
 import com.gmail.goosius.siegewar.TownOccupationController;
-import com.palmergames.bukkit.towny.TownySettings;
 import com.palmergames.bukkit.towny.TownyUniverse;
 import com.palmergames.bukkit.towny.object.Government;
 import com.palmergames.bukkit.towny.object.Nation;
@@ -204,7 +203,7 @@ public class TownResourceProductionController {
         for(int i = 0; i < discoveredResources.size(); i++) {
             material = discoveredResources.get(i);
             //If town does not meet the min level, produced amt is zero
-            if(TownySettings.calcTownLevelId(town) < TownyResourcesSettings.getProductionTownLevelRequirementPerResourceLevel().get(i)) {
+            if(town.getLevel() < TownyResourcesSettings.getProductionTownLevelRequirementPerResourceLevel().get(i)) {
                 finalProducedAmount = 0;
             } else {
                 baseProducedAmount = allOffers.get(material).getBaseAmountItems();

--- a/src/main/java/io/github/townyadvanced/townyresources/listeners/TownyResourcesNationEventListener.java
+++ b/src/main/java/io/github/townyadvanced/townyresources/listeners/TownyResourcesNationEventListener.java
@@ -1,17 +1,15 @@
 package io.github.townyadvanced.townyresources.listeners;
 
+import com.palmergames.adventure.text.Component;
 import com.palmergames.bukkit.towny.event.statusscreen.NationStatusScreenEvent;
 import com.palmergames.bukkit.towny.object.Nation;
+import com.palmergames.bukkit.towny.utils.TownyComponents;
 import io.github.townyadvanced.townyresources.metadata.TownyResourcesGovernmentMetaDataController;
 import io.github.townyadvanced.townyresources.settings.TownyResourcesSettings;
 import io.github.townyadvanced.townyresources.settings.TownyResourcesTranslation;
-import io.github.townyadvanced.townyresources.util.ChatTools;
 import io.github.townyadvanced.townyresources.util.TownyResourcesMessagingUtil;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
-
-import java.util.ArrayList;
-import java.util.List;
 
 /**
  * 
@@ -33,19 +31,17 @@ public class TownyResourcesNationEventListener implements Listener {
 			if(productionAsString.isEmpty() && availableAsString.isEmpty())
 				return;
 
-			//Resources:	
-			List<String> textLines = new ArrayList<>();
-			textLines.add(TownyResourcesTranslation.of("nation.screen.header"));
-				
+			//Resources:
+			Component component = Component.empty();
+			component = component.append(Component.newline());
+			component = component.append(TownyComponents.legacy(TownyResourcesTranslation.of("nation.screen.header"))).append(Component.newline());
+		
 			// > Daily Productivity [2]: 32 oak Log, 32 sugar cane
-			String[] resourcesAsFormattedArray = TownyResourcesMessagingUtil.formatResourcesStringForGovernmentScreenDisplay(productionAsString); 
-			textLines.addAll(ChatTools.listArr(resourcesAsFormattedArray, TownyResourcesTranslation.of("nation.screen.daily.production", resourcesAsFormattedArray.length)));
-
-			// > Available For Collection [2]: 64 oak log, 64 sugar cane
-			resourcesAsFormattedArray = TownyResourcesMessagingUtil.formatResourcesStringForGovernmentScreenDisplay(availableAsString); 
-			textLines.addAll(ChatTools.listArr(resourcesAsFormattedArray, TownyResourcesTranslation.of("nation.screen.available.for.collection", resourcesAsFormattedArray.length)));
+			component = component.append(TownyResourcesMessagingUtil.getSubComponentForGovernmentScreens(productionAsString, "nation.screen.daily.production")).append(Component.newline());
 			
-			event.addLines(textLines);
+			// > Available For Collection [2]: 64 oak log, 64 sugar cane
+			component = component.append(TownyResourcesMessagingUtil.getSubComponentForGovernmentScreens(availableAsString, "nation.screen.available.for.collection")).append(Component.newline());
+			event.getStatusScreen().addComponentOf("TownyResources", component);
 		}
 	}
 }

--- a/src/main/java/io/github/townyadvanced/townyresources/listeners/TownyResourcesTownEventListener.java
+++ b/src/main/java/io/github/townyadvanced/townyresources/listeners/TownyResourcesTownEventListener.java
@@ -1,17 +1,15 @@
 package io.github.townyadvanced.townyresources.listeners;
 
+import com.palmergames.adventure.text.Component;
 import com.palmergames.bukkit.towny.event.statusscreen.TownStatusScreenEvent;
 import com.palmergames.bukkit.towny.object.Town;
+import com.palmergames.bukkit.towny.utils.TownyComponents;
 import io.github.townyadvanced.townyresources.metadata.TownyResourcesGovernmentMetaDataController;
 import io.github.townyadvanced.townyresources.settings.TownyResourcesSettings;
 import io.github.townyadvanced.townyresources.settings.TownyResourcesTranslation;
-import io.github.townyadvanced.townyresources.util.ChatTools;
 import io.github.townyadvanced.townyresources.util.TownyResourcesMessagingUtil;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
-
-import java.util.ArrayList;
-import java.util.List;
 
 /**
  * 
@@ -33,19 +31,17 @@ public class TownyResourcesTownEventListener implements Listener {
 			if(productionAsString.isEmpty() && availableAsString.isEmpty())
 				return;
 
-			//Resources:	
-			List<String> textLines = new ArrayList<>();
-			textLines.add(TownyResourcesTranslation.of("town.screen.header"));
-				
+			//Resources:
+			Component component = Component.empty();
+			component = component.append(Component.newline());
+			component = component.append(TownyComponents.legacy(TownyResourcesTranslation.of("town.screen.header"))).append(Component.newline());
+
 			// > Daily Productivity [2]: 32 oak Log, 32 sugar cane
-			String[] resourcesAsFormattedArray = TownyResourcesMessagingUtil.formatResourcesStringForGovernmentScreenDisplay(productionAsString); 
-			textLines.addAll(ChatTools.listArr(resourcesAsFormattedArray, TownyResourcesTranslation.of("town.screen.daily.production", resourcesAsFormattedArray.length)));
+			component = component.append(TownyResourcesMessagingUtil.getSubComponentForGovernmentScreens(productionAsString, "town.screen.daily.production")).append(Component.newline());
 
 			// > Available For Collection [2]: 64 oak log, 64 sugar cane
-			resourcesAsFormattedArray = TownyResourcesMessagingUtil.formatResourcesStringForGovernmentScreenDisplay(availableAsString); 
-			textLines.addAll(ChatTools.listArr(resourcesAsFormattedArray, TownyResourcesTranslation.of("town.screen.available.for.collection", resourcesAsFormattedArray.length)));
-			
-			event.addLines(textLines);
+			component = component.append(TownyResourcesMessagingUtil.getSubComponentForGovernmentScreens(availableAsString, "town.screen.available.for.collection")).append(Component.newline());
+			event.getStatusScreen().addComponentOf("TownyResources", component);
 		}
 	}
 }

--- a/src/main/java/io/github/townyadvanced/townyresources/util/TownyResourcesMessagingUtil.java
+++ b/src/main/java/io/github/townyadvanced/townyresources/util/TownyResourcesMessagingUtil.java
@@ -11,8 +11,13 @@ import org.bukkit.Material;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 
+import com.palmergames.adventure.text.Component;
+import com.palmergames.adventure.text.event.HoverEvent;
+import com.palmergames.adventure.text.format.NamedTextColor;
 import com.palmergames.bukkit.towny.TownyAPI;
+import com.palmergames.bukkit.towny.utils.TownyComponents;
 import com.palmergames.bukkit.util.Colors;
+import com.palmergames.util.StringMgmt;
 
 import io.github.townyadvanced.townyresources.TownyResources;
 import io.github.townyadvanced.townyresources.settings.TownyResourcesTranslation;
@@ -57,9 +62,9 @@ public class TownyResourcesMessagingUtil {
             return new String[0];
         } else {
             String[] resourcesAsFormattedArray = convertResourceAmountsStringToFormattedArray(resourcesAsString);
-            if(resourcesAsFormattedArray.length > 20) {
-                resourcesAsFormattedArray = Arrays.copyOf(resourcesAsFormattedArray, 21);
-                resourcesAsFormattedArray[20] = "...";
+            if(resourcesAsFormattedArray.length > 10) {
+                resourcesAsFormattedArray = Arrays.copyOf(resourcesAsFormattedArray, 11);
+                resourcesAsFormattedArray[10] = "...";
             }
             return resourcesAsFormattedArray;
         }
@@ -105,6 +110,24 @@ public class TownyResourcesMessagingUtil {
         }
         return resourcesAsFormattedList.toArray(new String[0]);
     }
+    
+    
+    /**
+     * Used in the Government StatusScreen events to make the production/available components.
+     * 
+     * @param resourcesAsString String representing the Resources due.
+     * @param langString The language string which will be applied to the Component.
+     * @return Component to be used in the StatusScreen
+     */
+    public static Component getSubComponentForGovernmentScreens(String resourcesAsString, String langString) {
+		String[] resourcesAsFormattedArray = convertResourceAmountsStringToFormattedArray(resourcesAsString);
+		String[] resourcesForDisplay = formatResourcesStringForGovernmentScreenDisplay(resourcesAsString);
+		Component component = Component.empty();
+		component = component.append(TownyComponents.legacy(TownyResourcesTranslation.of(langString , resourcesAsFormattedArray.length)))
+			.append(Component.text(StringMgmt.join(resourcesForDisplay, ", "), NamedTextColor.WHITE));
+		component = component.hoverEvent(HoverEvent.showText(Component.text(StringMgmt.join(resourcesAsFormattedArray, ", "))));
+		return component;
+	}
     
     public static String formatExtractionCategoryNameForDisplay(ResourceExtractionCategory resourceExtractionCategory) {
         String categoryName = resourceExtractionCategory.getName();


### PR DESCRIPTION
Updates StatusScreens to use Component system instead of older
EventLines.

Production and Available lists are now shorter by default, with the full
lists hidden in the component HoverEvents.

Min. Towny Version bumped to 0.98.3.5.

Closes #93

Removes deprecated code pertaining to getting the Town level.