### PR TITLE
Change TownyResources collection to put items directly into a players inventory.

### DIFF
--- a/src/main/java/io/github/townyadvanced/townyresources/util/TownyResourcesMessagingUtil.java
+++ b/src/main/java/io/github/townyadvanced/townyresources/util/TownyResourcesMessagingUtil.java
@@ -102,6 +102,8 @@ public class TownyResourcesMessagingUtil {
         String materialName;
         String translatedMaterialName;
         for(String resourceAsString: resourcesAsArray) {
+            if (resourceAsString.isEmpty())
+                continue;
             amountAndMaterialName = resourceAsString.split("-");
             amount = amountAndMaterialName[0];
             materialName = amountAndMaterialName[1];

--- a/src/main/resources/english.yml
+++ b/src/main/resources/english.yml
@@ -1,5 +1,5 @@
 name: TownyResources
-version: 0.07
+version: 0.08
 language: english
 author: Goosius
 website: 'https://github.com/TownyAdvanced/TownyResources'
@@ -162,3 +162,6 @@ all_resources_rerolled: "All discovered town resources have been rerolled"
 admin_help_bypass: "Bypasses extraction limit."
 bypass_on: "Now bypassing extraction limit."
 bypass_off: "No longer bypassing extraction limit."
+
+#Added in 0.08
+resource.you_have_no_room_in_your_inventory: 'You do not have any free slots in your inventory. Make some room before collecting.'

--- a/src/main/resources/german.yml
+++ b/src/main/resources/german.yml
@@ -1,5 +1,5 @@
 name: TownyResources
-version: 0.07
+version: 0.08
 language: german
 author: ConfusedAlex
 website: 'https://github.com/TownyAdvanced/TownyResources'
@@ -162,3 +162,6 @@ all_resources_rerolled: "Alle entdeckten Ressourcen sind neu gewürfelt worden."
 admin_help_bypass: "Umgeht die Entnahmegrenze."
 bypass_on: "Entnahmegrenze wird nun umgangen."
 bypass_off: "Entnahmegrenze wird nun nicht mehr umgangen."
+
+#Added in 0.08
+resource.you_have_no_room_in_your_inventory: 'You do not have any free slots in your inventory. Make some room before collecting.'

--- a/src/main/resources/portugues.yml
+++ b/src/main/resources/portugues.yml
@@ -1,5 +1,5 @@
 name: TownyResources
-version: 0.07
+version: 0.08
 language: Português - Brasil
 author: YuriGG_
 website: 'https://github.com/TownyAdvanced/TownyResources'
@@ -162,3 +162,6 @@ all_resources_rerolled: "Todos os recursos da cidade descobertos foram relançad
 admin_help_bypass: "Ignora o limite de extração."
 bypass_on: "Agora ignorando o limite de extração."
 bypass_off: "No longer bypassing extraction limit."
+
+#Added in 0.08
+resource.you_have_no_room_in_your_inventory: 'You do not have any free slots in your inventory. Make some room before collecting.'

--- a/src/main/resources/spanish.yml
+++ b/src/main/resources/spanish.yml
@@ -1,5 +1,5 @@
 name: TownyResources
-version: 0.07
+version: 0.08
 language: spanish
 author: ElMoha943
 website: 'https://github.com/TownyAdvanced/TownyResources'
@@ -162,3 +162,6 @@ all_resources_rerolled: "Todos los recursos descubiertos fueron regenerados"
 admin_help_bypass: "Ignora el limite de extraccion."
 bypass_on: "Ignorando el limite de extraccion."
 bypass_off: "Ya no estas ignorando el limite de extraccion."
+
+#Added in 0.08
+resource.you_have_no_room_in_your_inventory: 'You do not have any free slots in your inventory. Make some room before collecting.'


### PR DESCRIPTION
They must have empty slots to collect. If it doesn't fit the same command can be run again after they make room.

- Closes #95.