### PR TITLE
0.3.0 Add town-level resourceProductionModifier to resource production.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,14 +2,14 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.github.townyadvanced</groupId>
   <artifactId>TownyResources</artifactId>
-  <version>0.2.5</version>
+  <version>0.3.0</version>
   <name>townyresources</name> <!-- Leave lower-cased -->
 
   <properties>
     <java.version>1.8</java.version>
     <project.bukkitAPIVersion>1.15</project.bukkitAPIVersion>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <towny.version>0.98.5.0</towny.version>
+    <towny.version>0.98.6.3</towny.version>
   </properties>
 
   <repositories>
@@ -50,7 +50,7 @@
 	<dependency>
       <groupId>com.github.TownyAdvanced</groupId>
       <artifactId>Towny</artifactId>
-      <version>0.98.5.0</version>
+      <version>0.98.6.3</version>
       <scope>provided</scope>
 	</dependency>
     <dependency>
@@ -89,6 +89,12 @@
       <version>6.7.5-SNAPSHOT</version>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>com.github.bsideup.jabel</groupId>
+      <artifactId>jabel-javac-plugin</artifactId>
+      <version>1.0.0</version>
+      <scope>provided</scope>
+    </dependency>
   </dependencies>
 
   <build>
@@ -98,8 +104,12 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.8.1</version>
         <configuration>
-          <source>1.8</source>
-          <target>1.8</target>
+          <release>8</release>
+          <source>${java.version}</source>
+          <target>${java.version}</target>
+          <compilerArgs>
+            <arg>-Xplugin:jabel</arg>
+          </compilerArgs>
         </configuration>
       </plugin>
     </plugins>
@@ -110,5 +120,29 @@
       </resource>
     </resources>
   </build>
-  
+
+  <profiles>
+    <profile>
+      <id>intellij-idea-only</id>
+      <activation>
+        <property>
+          <name>idea.maven.embedder.version</name>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <configuration>
+              <release>${java.version}</release>
+              <compilerArgs>
+                <arg>--enable-preview</arg>
+              </compilerArgs>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>

--- a/src/main/java/io/github/townyadvanced/townyresources/TownyResources.java
+++ b/src/main/java/io/github/townyadvanced/townyresources/TownyResources.java
@@ -21,7 +21,7 @@ import java.io.File;
 public class TownyResources extends JavaPlugin {
 	
 	private static TownyResources plugin;
-	private static Version requiredTownyVersion = Version.fromString("0.98.5.0");
+	private static Version requiredTownyVersion = Version.fromString("0.98.6.3");
 	private static boolean siegeWarInstalled;
 	private static boolean dynmapTownyInstalled; 
 	private static boolean languageUtilsInstalled;

--- a/src/main/java/io/github/townyadvanced/townyresources/controllers/TownResourceProductionController.java
+++ b/src/main/java/io/github/townyadvanced/townyresources/controllers/TownResourceProductionController.java
@@ -1,6 +1,7 @@
 package io.github.townyadvanced.townyresources.controllers;
 
 import com.gmail.goosius.siegewar.TownOccupationController;
+import com.palmergames.bukkit.towny.TownySettings;
 import com.palmergames.bukkit.towny.TownyUniverse;
 import com.palmergames.bukkit.towny.object.Government;
 import com.palmergames.bukkit.towny.object.Nation;
@@ -271,10 +272,12 @@ public class TownResourceProductionController {
             String resource;
             int quantityToProduce;
             int currentQuantity;
+            double townLevelModifier;
             int storageLimit;
             for(Map.Entry<String, Integer> townProductionEntry: townDailyProduction.entrySet()) {
                 resource = townProductionEntry.getKey();
-                quantityToProduce =townProductionEntry.getValue();
+                townLevelModifier = government instanceof Town town ? TownySettings.getTownLevel(town).resourceProductionModifier() : 1.0;
+                quantityToProduce = (int) (townProductionEntry.getValue() * townLevelModifier);
                 if(quantityToProduce == 0)
                     continue;
                 if(availableResources.containsKey(resource)) {

--- a/src/main/java/io/github/townyadvanced/townyresources/listeners/TownyResourcesDynmapTownyListener.java
+++ b/src/main/java/io/github/townyadvanced/townyresources/listeners/TownyResourcesDynmapTownyListener.java
@@ -20,6 +20,7 @@ public class TownyResourcesDynmapTownyListener implements Listener {
         if (TownyResourcesSettings.isEnabled()) {
             if (event.getDescription().contains("%town_resources%")) {
                 String productionAsString = TownyResourcesGovernmentMetaDataController.getDailyProduction(event.getTown());
+                productionAsString = TownyResourcesMessagingUtil.adjustAmountsForTownLevelModifier(event.getTown(), productionAsString);
                 String formattedProductionAsString = TownyResourcesMessagingUtil.formatProductionStringForDynmapTownyDisplay(productionAsString);
                 String finalDescription = event.getDescription().replace("%town_resources%", formattedProductionAsString);
                 event.setDescription(finalDescription);

--- a/src/main/java/io/github/townyadvanced/townyresources/listeners/TownyResourcesTownEventListener.java
+++ b/src/main/java/io/github/townyadvanced/townyresources/listeners/TownyResourcesTownEventListener.java
@@ -1,6 +1,7 @@
 package io.github.townyadvanced.townyresources.listeners;
 
 import com.palmergames.adventure.text.Component;
+import com.palmergames.bukkit.towny.TownySettings;
 import com.palmergames.bukkit.towny.event.statusscreen.TownStatusScreenEvent;
 import com.palmergames.bukkit.towny.object.Town;
 import com.palmergames.bukkit.towny.utils.TownyComponents;
@@ -8,6 +9,10 @@ import io.github.townyadvanced.townyresources.metadata.TownyResourcesGovernmentM
 import io.github.townyadvanced.townyresources.settings.TownyResourcesSettings;
 import io.github.townyadvanced.townyresources.settings.TownyResourcesTranslation;
 import io.github.townyadvanced.townyresources.util.TownyResourcesMessagingUtil;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 
@@ -31,17 +36,32 @@ public class TownyResourcesTownEventListener implements Listener {
 			if(productionAsString.isEmpty() && availableAsString.isEmpty())
 				return;
 
+			productionAsString = TownyResourcesMessagingUtil.adjustAmountsForTownLevelModifier(town, productionAsString);
+			
 			//Resources:
 			Component component = Component.empty();
 			component = component.append(Component.newline());
-			component = component.append(TownyComponents.legacy(TownyResourcesTranslation.of("town.screen.header"))).append(Component.newline());
+			component = component.append(TownyComponents.legacy(TownyResourcesTranslation.of("town.screen.header"))).appendNewline();
 
 			// > Daily Productivity [2]: 32 oak Log, 32 sugar cane
-			component = component.append(TownyResourcesMessagingUtil.getSubComponentForGovernmentScreens(productionAsString, "town.screen.daily.production")).append(Component.newline());
+			component = component.append(TownyResourcesMessagingUtil.getSubComponentForGovernmentScreens(productionAsString, "town.screen.daily.production")).appendNewline();
 
 			// > Available For Collection [2]: 64 oak log, 64 sugar cane
-			component = component.append(TownyResourcesMessagingUtil.getSubComponentForGovernmentScreens(availableAsString, "town.screen.available.for.collection")).append(Component.newline());
+			component = component.append(TownyResourcesMessagingUtil.getSubComponentForGovernmentScreens(availableAsString, "town.screen.available.for.collection")).appendNewline();
+			// > TownLevel Modifier: +10%.
+			if (TownySettings.getTownLevel(town).resourceProductionModifier() != 1.0)
+				component = component.append(getTownModifierComponent(town)).appendNewline();
 			event.getStatusScreen().addComponentOf("TownyResources", component);
 		}
+	}
+
+	private Component getTownModifierComponent(Town town) {
+		double townModifier = TownySettings.getTownLevel(town).resourceProductionModifier();
+		String modifierSlug = "";
+		if (townModifier > 1.0)
+			modifierSlug = "+" + BigDecimal.valueOf((townModifier - 1) * 100).setScale(2, RoundingMode.HALF_UP).doubleValue();
+		if (townModifier < 1.0)
+			modifierSlug = String.valueOf(BigDecimal.valueOf((townModifier * 100) - 100).setScale(2, RoundingMode.HALF_UP).doubleValue()); 
+		return Component.text(TownyResourcesTranslation.of("town.screen.town.level.modifier", modifierSlug)).append(Component.text("%"));
 	}
 }

--- a/src/main/java/io/github/townyadvanced/townyresources/util/TownyResourcesMessagingUtil.java
+++ b/src/main/java/io/github/townyadvanced/townyresources/util/TownyResourcesMessagingUtil.java
@@ -15,6 +15,8 @@ import com.palmergames.adventure.text.Component;
 import com.palmergames.adventure.text.event.HoverEvent;
 import com.palmergames.adventure.text.format.NamedTextColor;
 import com.palmergames.bukkit.towny.TownyAPI;
+import com.palmergames.bukkit.towny.TownySettings;
+import com.palmergames.bukkit.towny.object.Town;
 import com.palmergames.bukkit.towny.utils.TownyComponents;
 import com.palmergames.bukkit.util.Colors;
 import com.palmergames.util.StringMgmt;
@@ -183,4 +185,21 @@ public class TownyResourcesMessagingUtil {
         //Couldn't find a translation. Return un-translated material name
         return WordUtils.capitalizeFully(materialName.replaceAll("_", " "));
     }
+
+	public static String adjustAmountsForTownLevelModifier(Town town, String productionAsString) {
+        List<String> resourcesAsFormattedList = new ArrayList<>();
+        String[] resourcesAsArray = productionAsString.split(",");
+        String[] amountAndMaterialName;
+        String amount;
+        String materialName;
+        for(String resourceAsString: resourcesAsArray) {
+            if (resourceAsString.isEmpty())
+                continue;
+            amountAndMaterialName = resourceAsString.split("-");
+            amount = String.valueOf((int) (Integer.valueOf(amountAndMaterialName[0]) * TownySettings.getTownLevel(town).resourceProductionModifier()));
+            materialName = amountAndMaterialName[1];
+            resourcesAsFormattedList.add(amount + "-" + materialName);
+        }
+        return StringMgmt.join(resourcesAsFormattedList,",");
+	}
 }

--- a/src/main/resources/chinese.yml
+++ b/src/main/resources/chinese.yml
@@ -1,5 +1,5 @@
 name: TownyResources
-version: 0.09
+version: 0.10
 language: chinese
 author: Nailm
 website: 'https://github.com/TownyAdvanced/TownyResources'
@@ -35,6 +35,7 @@ admin_help_reload: '重载插件配置文件.'
 town.screen.header: "&2城镇资源:"
 town.screen.daily.production: '&2 > 每日产出 &a[%s]&2: &f'
 town.screen.available.for.collection: '&2 > 可收集 &a[%s]&2: &f'
+town.screen.town.level.modifier: '&2 > Town Level Modifier: &f %s'
 
 ### Nation Screen
 nation.screen.header: "&2国家资源:"

--- a/src/main/resources/english.yml
+++ b/src/main/resources/english.yml
@@ -1,5 +1,5 @@
 name: TownyResources
-version: 0.09
+version: 0.10
 language: english
 author: Goosius
 website: 'https://github.com/TownyAdvanced/TownyResources'
@@ -35,6 +35,7 @@ admin_help_reload: 'Reload TownyResources.'
 town.screen.header: "&2Resources:"
 town.screen.daily.production: '&2 > Daily Production &a[%s]&2: &f'
 town.screen.available.for.collection: '&2 > Available For Collection &a[%s]&2: &f'
+town.screen.town.level.modifier: '&2 > Town Level Modifier: &f %s'
 
 ### Nation Screen
 nation.screen.header: "&2Resources:"

--- a/src/main/resources/german.yml
+++ b/src/main/resources/german.yml
@@ -1,5 +1,5 @@
 name: TownyResources
-version: 0.09
+version: 0.10
 language: german
 author: ConfusedAlex
 website: 'https://github.com/TownyAdvanced/TownyResources'
@@ -35,6 +35,7 @@ admin_help_reload: 'TownyResources neuladen.'
 town.screen.header: "&2Ressourcen:"
 town.screen.daily.production: '&2 > Tägliche Produktion &a[%s]&2: &f'
 town.screen.available.for.collection: '&2 > Verfügbar zum einsammeln &a[%s]&2: &f'
+town.screen.town.level.modifier: '&2 > Town Level Modifier: &f %s'
 
 ### Nation Screen
 nation.screen.header: "&2Ressourcen:"

--- a/src/main/resources/portugues.yml
+++ b/src/main/resources/portugues.yml
@@ -1,5 +1,5 @@
 name: TownyResources
-version: 0.09
+version: 0.10
 language: Português - Brasil
 author: YuriGG_
 website: 'https://github.com/TownyAdvanced/TownyResources'
@@ -35,6 +35,7 @@ admin_help_reload: 'Reload TownyResources.'
 town.screen.header: "&2Recursos:"
 town.screen.daily.production: '&2 > Produção diaria &a[%s]&2: &f'
 town.screen.available.for.collection: '&2 > Pronto para coleta &a[%s]&2: &f'
+town.screen.town.level.modifier: '&2 > Town Level Modifier: &f %s'
 
 ### Nation Screen
 nation.screen.header: "&2Recursos:"

--- a/src/main/resources/spanish.yml
+++ b/src/main/resources/spanish.yml
@@ -1,5 +1,5 @@
 name: TownyResources
-version: 0.09
+version: 0.10
 language: spanish
 author: ElMoha943
 website: 'https://github.com/TownyAdvanced/TownyResources'
@@ -35,6 +35,7 @@ admin_help_reload: 'Recargar TownyResources.'
 town.screen.header: "&2Recursos:"
 town.screen.daily.production: '&2 > Produccion Diaria &a[%s]&2: &f'
 town.screen.available.for.collection: '&2 > Disponible para recoleccion &a[%s]&2: &f'
+town.screen.town.level.modifier: '&2 > Town Level Modifier: &f %s'
 
 ### Nation Screen
 nation.screen.header: "&2Recursos:"


### PR DESCRIPTION
Towns now have their production amounts altered based on the TownLevel resourceProductionModifier.

Resources are displayed with multiplier-altered amounts in the dynmap-towny infowindows and in the town status screen.

The Town status screen now comes with a modifier % when a modification is made.

When towns earn resources on a new day, the amount given is altered based on their current town level modifier.

Bump min. Towny version to 0.98.6.3.

Bump lang files to 0.10.

Jabel added to pom.

Closes #112 