### PR TITLE
Customizable list of blocks which do not drop when extraction limit reached.

### DIFF
--- a/src/main/java/io/github/townyadvanced/townyresources/controllers/PlayerExtractionLimitsController.java
+++ b/src/main/java/io/github/townyadvanced/townyresources/controllers/PlayerExtractionLimitsController.java
@@ -177,12 +177,12 @@ public class PlayerExtractionLimitsController {
             CategoryExtractionRecord categoryExtractionRecord = getCategoryExtractionRecord(playerExtractionRecord, drop.getType());                                            
                  
             /* 
-             * If player is at the limit, cancel the drop (except if ANCIENT_DEBRIS, then cancel the whole break).
+             * If player is at the limit, cancel the drop (except if ANCIENT_DEBRIS or other blocks that are considered unbreakable, then cancel the whole break).
              *
              * If player is not at the limit, add extracted amount to record.                    
              */
             if(categoryExtractionRecord.isExtractionLimitReached()) {
-                if(drop.getType() == Material.ANCIENT_DEBRIS) {
+                if (TownyResourcesSettings.isUnbreakableWhenExtractionLimitHit(drop.getType().name())) {
                     event.setCancelled(true);                    
                 } else {
                     event.setDropItems(false);                    

--- a/src/main/java/io/github/townyadvanced/townyresources/settings/TownyResourcesConfigNodes.java
+++ b/src/main/java/io/github/townyadvanced/townyresources/settings/TownyResourcesConfigNodes.java
@@ -150,6 +150,12 @@ public enum TownyResourcesConfigNodes {
 			"# 1 - The name of the category (used for messaging)",
 			"# 2-  The daily limit per player (in stacks)",
 			"# 3-  The list of materials in the category"),
+	RESOURCE_EXTRACTION_LIMITS_UNBREAKABLES(
+			"resource_extraction_limits.unbreakables",
+			"ANCIENT_DEBRIS",
+			"",
+			"# A list of blocks which cannot be broken when the player hits the extraction limit for this type.",
+			"# Ex: unbreakables: ANCIENT_DEBRIS,DIAMOND_BLOCK"),
 	TOWN_RESOURCES(
 			"town_resources",
 			"",

--- a/src/main/java/io/github/townyadvanced/townyresources/settings/TownyResourcesSettings.java
+++ b/src/main/java/io/github/townyadvanced/townyresources/settings/TownyResourcesSettings.java
@@ -388,6 +388,10 @@ public class TownyResourcesSettings {
 		return getInt(TownyResourcesConfigNodes.RESOURCE_EXTRACTION_LIMITS_COOLDOWN_AFTER_DAILY_LIMIT_WARNING_MESSAGE_MILLIS);
 	}
 
+	public static boolean isUnbreakableWhenExtractionLimitHit(String material) {
+		return getStrArr(TownyResourcesConfigNodes.RESOURCE_EXTRACTION_LIMITS_UNBREAKABLES).contains(material);
+	}
+
 	public static boolean isNonDynamicAmountMaterial(String material) {
 		return getStrArr(TownyResourcesConfigNodes.TOWN_RESOURCES_OFFERS_MATERIALS_WITH_NON_DYNAMIC_AMMOUNTS).contains(material);
 	}


### PR DESCRIPTION
New Config Option: resource_extraction_limits.unbreakables
  - Default: ANCIENT_DEBRIS
  - A list of blocks which cannot be broken when the player hits the extraction limit for this type.
  - Ex: unbreakables: ANCIENT_DEBRIS,DIAMOND_BLOCK

Closes #49.