### PR TITLE
Drop support for MythicMobs v4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,21 +72,9 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>io.lumine.xikage</groupId>
-      <artifactId>MythicMobs</artifactId>
-      <version>4.9.1</version>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
       <groupId>io.lumine</groupId>
       <artifactId>Mythic-Dist</artifactId>
-      <version>5.2.1</version>  
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>io.lumine</groupId>
-      <artifactId>MythicLib-dist</artifactId>
-      <version>1.4</version>  
+      <version>5.3.5</version>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/src/main/java/io/github/townyadvanced/townyresources/TownyResources.java
+++ b/src/main/java/io/github/townyadvanced/townyresources/TownyResources.java
@@ -39,7 +39,6 @@ public class TownyResources extends JavaPlugin {
 	private static boolean dynmapTownyInstalled; 
 	private static boolean languageUtilsInstalled;
 	private static boolean slimeFunInstalled;
-	private static boolean legacyMythicMobsInstalled;
 	private static boolean mythicMobsInstalled;
 	private static boolean mmmoItemsInstalled;
 	
@@ -219,10 +218,6 @@ public class TownyResources extends JavaPlugin {
 
 	public boolean isMythicMobsInstalled() { return mythicMobsInstalled; }
 	
-	public boolean isMythicMobsLegacy() {
-		return legacyMythicMobsInstalled;
-	}
-	
 	public boolean isMythicMobsV5() {
 		return mythicMobsInstalled;
 	}
@@ -260,10 +255,7 @@ public class TownyResources extends JavaPlugin {
 		Plugin mythicMobs = Bukkit.getPluginManager().getPlugin("MythicMobs");
 		if(mythicMobs != null) {
 			String className = Bukkit.getServer().getPluginManager().getPlugin("MythicMobs").getClass().getName();
-			if (className.equals("io.lumine.xikage.mythicmobs.MythicMobs")) {
-				legacyMythicMobsInstalled = true;
-				info("  Legacy Mythic Mobs Integration Enabled");
-			} else if (className.equals("io.lumine.mythic.bukkit.MythicBukkit")) {
+			if (className.equals("io.lumine.mythic.bukkit.MythicBukkit")) {
 				mythicMobsInstalled = true;
 				info("  Mythic Mobs Integration Enabled");
 			} else {

--- a/src/main/java/io/github/townyadvanced/townyresources/util/MythicMobsUtil.java
+++ b/src/main/java/io/github/townyadvanced/townyresources/util/MythicMobsUtil.java
@@ -5,17 +5,16 @@ import java.util.Optional;
 import org.bukkit.inventory.ItemStack;
 
 import io.github.townyadvanced.townyresources.TownyResources;
-import io.lumine.xikage.mythicmobs.items.MythicItem;
+import io.lumine.mythic.bukkit.MythicBukkit;
+import io.lumine.mythic.core.items.MythicItem;
 
 public class MythicMobsUtil {
 
 
 	public static ItemStack getMythicItemStack(String materialName) {
 		ItemStack mythicItem = null;
-		if (TownyResources.getPlugin().isMythicMobsLegacy()) {
-			mythicItem = io.lumine.xikage.mythicmobs.MythicMobs.inst().getItemManager().getItemStack(materialName);
-		} else if (TownyResources.getPlugin().isMythicMobsV5()) {
-			mythicItem = io.lumine.mythic.bukkit.MythicBukkit.inst().getItemManager().getItemStack(materialName);
+		if (TownyResources.getPlugin().isMythicMobsV5()) {
+			mythicItem = MythicBukkit.inst().getItemManager().getItemStack(materialName);
 		}
 		return mythicItem;
 	}
@@ -29,31 +28,10 @@ public class MythicMobsUtil {
 
 	public static String getMaterialNameForDisplay(String materialName) {
 		String name = null;
-		if (TownyResources.getPlugin().isMythicMobsLegacy()) {
-			Optional<MythicItem> maybeMythicItem = io.lumine.xikage.mythicmobs.MythicMobs.inst().getItemManager()
-					.getItem(materialName);
-
+		if (TownyResources.getPlugin().isMythicMobsV5()) {
+			Optional<MythicItem> maybeMythicItem = MythicBukkit.inst().getItemManager().getItem(materialName);
 			if (maybeMythicItem.isPresent()) {
 				MythicItem mythicItem = maybeMythicItem.get();
-				String maybeDisplayName = mythicItem.getDisplayName();
-				if (maybeDisplayName != null) {
-					return maybeDisplayName.replaceAll("[^\\w\\s]\\w", "");
-				} else {
-					// MythicItem#getDisplayName() will always return null for imported items
-					// try to extract the name from the raw config data
-					if (mythicItem.getConfig().isSet("ItemStack")) {
-						ItemStack is = mythicItem.getConfig().getItemStack("ItemStack", (String) null);
-						if (is != null && is.hasItemMeta() && is.getItemMeta().hasDisplayName()) {
-							return is.getItemMeta().getDisplayName();
-						}
-					}
-				}
-			}
-		} else if (TownyResources.getPlugin().isMythicMobsV5()) {
-			Optional<io.lumine.mythic.core.items.MythicItem> maybeMythicItem = io.lumine.mythic.bukkit.MythicBukkit
-					.inst().getItemManager().getItem(materialName);
-			if (maybeMythicItem.isPresent()) {
-				io.lumine.mythic.core.items.MythicItem mythicItem = maybeMythicItem.get();
 				String maybeDisplayName = mythicItem.getDisplayName();
 				if (maybeDisplayName != null) {
 					return maybeDisplayName.replaceAll("[^\\w\\s]\\w", "");


### PR DESCRIPTION
v5 is now in their free category, and the maven repo used to support v4 items is no longer working out. v4 is probably very old at this point.

Closes #135.