### PR TITLE
Make it possible for a town to re-roll their Resources for a fee.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ The plugin also has an optional feature to protect resource value, via daily pla
    - Note: Do not add Eggs, Honeycomb, or Honey Bottle to the daily-limits list, as these limit types are not yet operational.
 6. Give the permission nodes required to use the plugin using the following commands: 
     ```
+    /ta townyperms group towns.mayor addperm townyresources.command.town.reroll   <-- only required if you have enabled town's ability to re-roll resources.
+
     /ta townyperms group towns.mayor addperm townyresources.command.towncollect
 
     /ta townyperms group towns.mayor addperm townyresources.command.survey
@@ -135,6 +137,9 @@ The plugin also has an optional feature to protect resource value, via daily pla
 ###### Collecting Town Resources
 - To collect town resources, as a mayor/assistant/treasurer, enter your town and run `/t resources collect`
 - The available resources will then be dropped at your position.
+###### Re-rolling Town Resources
+- If your server has enabled re-rolling, you will be able to use /t resources reroll, for a fee.
+- This will cause your town's resources to be re-discovered.
 ### Nation Production
 ###### Information
 - Nation production & collection information is shown on the nation screen. Example:

--- a/src/main/java/io/github/townyadvanced/townyresources/enums/TownyResourcesPermissionNodes.java
+++ b/src/main/java/io/github/townyadvanced/townyresources/enums/TownyResourcesPermissionNodes.java
@@ -9,6 +9,7 @@ public enum TownyResourcesPermissionNodes {
 
 	TOWNY_RESOURCES_COMMAND("townyresources.command.*"),
 	TOWNY_RESOURCES_COMMAND_SURVEY("townyresources.command.survey"),  //Do a resource survey in a town
+	TOWNY_RESOURCES_COMMAND_TOWN_REROLL("townyresources.command.town.reroll"),  //Re roll a town's resources for a fee.
 	TOWNY_RESOURCES_COMMAND_TOWN_COLLECT("townyresources.command.towncollect"),  //Collect your town's share of extracted resources
 	TOWNY_RESOURCES_COMMAND_NATION_COLLECT("townyresources.command.nationcollect"), //Collect your nation's share of extracted resources
 	TOWNY_RESOURCES_ADMIN_COMMAND("townyresources.admin.command.*"),

--- a/src/main/java/io/github/townyadvanced/townyresources/settings/TownyResourcesConfigNodes.java
+++ b/src/main/java/io/github/townyadvanced/townyresources/settings/TownyResourcesConfigNodes.java
@@ -201,6 +201,13 @@ public enum TownyResourcesConfigNodes {
 			"",
 			"# If true, towns produce resources.",
 			"# if false, towns do not produce resource."),
+	TOWN_RESOURCES_PRODUCTION_REROLL_COST(
+			"town_resources.production.reroll_cost",
+			"-1.0",
+			"",
+			"# When above 0, a town can pay to reroll their resources.",
+			"# This is disabled by default to prevent rich towns being able to spam rerolls. Use cautiously."),
+	
 	TOWN_RESOURCES_PRODUCTION_TOWN_LEVEL_REQUIREMENT_PER_RESOURCE_LEVEL(
 			"town_resources.production.town_level_requirement_per_resource_level",
 			"2, 4, 6, 8",

--- a/src/main/java/io/github/townyadvanced/townyresources/settings/TownyResourcesSettings.java
+++ b/src/main/java/io/github/townyadvanced/townyresources/settings/TownyResourcesSettings.java
@@ -43,7 +43,11 @@ public class TownyResourcesSettings {
     public static List<Integer> getSurveyNumTownblocksRequirementsPerResourceLevel() {
     	return getIntegerList(TownyResourcesConfigNodes.TOWN_RESOURCES_SURVEYS_NUM_TOWNBLOCKS_REQUIREMENT_PER_RESOURCE_LEVEL);
 	}
-		
+
+	public static double getRerollCost() {
+		return getDouble(TownyResourcesConfigNodes.TOWN_RESOURCES_PRODUCTION_REROLL_COST);
+	}
+
 	public static List<Integer> getProductionPercentagesPerResourceLevel() {
 		return getIntegerList(TownyResourcesConfigNodes.TOWN_RESOURCES_PRODUCTION_PRODUCTIVITY_PERCENTAGE_PER_RESOURCE_LEVEL);
 	}

--- a/src/main/resources/lang/en-US.yml
+++ b/src/main/resources/lang/en-US.yml
@@ -86,6 +86,12 @@ townyresources.msg_err_not_enough_offers_left: "&cSurvey not possible, because t
 ### Production
 townyresources.production.message: "&b%s towns produced resources."
 
+### Rerolling
+townyresources.help_townreroll: 'For a price, reroll your town's resources.'
+townyresources.reroll_disabled: 'Re-rolling resources is disabled.'
+townyresources.cannot_afford_to_reroll: 'You cannot afford the cost to re-roll: %s'
+townyresources.reroll_confirmation_title: 'Re-rolling your town''s resources will cost %s. Do you want to continue?'
+
 ### Collection
 townyresources.help_towncollect: 'Collect all available resources at your town.'
 townyresources.help_nationcollect: 'Collect all available resources at your nation.'

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -16,6 +16,10 @@ permissions:
         description: User is able to do a survey.
         default: true
 
+    townyresources.command.town.reroll:
+        description: User is able to reroll their town's resources for a fee.
+        default: false
+
     townyresources.admin.command.*:
         description: User is able to do all townyresouces admin commands.
         default: op

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -14,7 +14,7 @@ description: This is an add-on plugin for Towny, which gives each town a unique 
 permissions:
     townyresources.command.survey:
         description: User is able to do a survey.
-        default: true
+        default: false
 
     townyresources.command.town.reroll:
         description: User is able to reroll their town's resources for a fee.


### PR DESCRIPTION
Closes #122 

Requires enabling it in the config and giving mayors the permission node to use the command:
`/ta townyperms group towns.mayor addperm townyresources.command.town.reroll`

```
  - New Config Option: town_resources.production.reroll_cost
    - Default: -1.0
    - When above 0, a town can pay to reroll their resources.
    - This is disabled by default to prevent rich towns being able to spam rerolls. Use cautiously.
```