### PR TITLE
Add the ability to force the max stack size to 64 when resources are collected

### DIFF
--- a/src/main/java/io/github/townyadvanced/townyresources/controllers/TownResourceCollectionController.java
+++ b/src/main/java/io/github/townyadvanced/townyresources/controllers/TownResourceCollectionController.java
@@ -7,6 +7,7 @@ import com.palmergames.bukkit.towny.object.Translatable;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
 import io.github.townyadvanced.townyresources.TownyResources;
 import io.github.townyadvanced.townyresources.metadata.TownyResourcesGovernmentMetaDataController;
+import io.github.townyadvanced.townyresources.settings.TownyResourcesSettings;
 import io.github.townyadvanced.townyresources.util.ItemsAdderUtil;
 import io.github.townyadvanced.townyresources.util.MMOItemsUtil;
 import io.github.townyadvanced.townyresources.util.MythicMobsUtil;
@@ -64,6 +65,12 @@ public class TownResourceCollectionController {
             return false;
         }
 
+        // Some plugin might be altering the max stack size of the player, and the server  
+        // admin doesn't want TR resources given out in stacks greater than 64.
+        int invSize = inv.getMaxStackSize();
+        if (TownyResourcesSettings.isMaxStackSizeLockedTo64() && invSize != 64)
+            inv.setMaxStackSize(64);
+
         final Map<Integer, ItemStack> itemsThatDontFit = inv.addItem(itemStackList.toArray(new ItemStack[0]));
         /* If map is not empty, some items were not added.... */
         if (!itemsThatDontFit.isEmpty()) {
@@ -84,6 +91,11 @@ public class TownResourceCollectionController {
 
         //Save government
         government.save();
+
+        // Reset the player's wonky max stack size.
+        if (TownyResourcesSettings.isMaxStackSizeLockedTo64() && invSize != 64)
+            inv.setMaxStackSize(invSize);
+
         return true;
     }
 

--- a/src/main/java/io/github/townyadvanced/townyresources/settings/TownyResourcesConfigNodes.java
+++ b/src/main/java/io/github/townyadvanced/townyresources/settings/TownyResourcesConfigNodes.java
@@ -239,6 +239,12 @@ public enum TownyResourcesConfigNodes {
 			"",
 			"# If a town is occupied, the occupying nation gets this percentage of town production.",
 			"# The town gets the rest."),
+	TOWN_RESOURCES_PRODUCTION_COLLECTION_FORCES_STACKSIZE_OF_64(
+			"town_resources.production.collection_forces_max_stacksize_of_64",
+			"true",
+			"",
+			"# Forces TownyResources to give resources out with a max stack size of 64.",
+			"# This is usually the case but you might have other plugins which will set a player's max stack size higher."),
 	TOWN_RESOURCES_OFFERS(
 			"town_resources.offers",
 			"",

--- a/src/main/java/io/github/townyadvanced/townyresources/settings/TownyResourcesSettings.java
+++ b/src/main/java/io/github/townyadvanced/townyresources/settings/TownyResourcesSettings.java
@@ -65,6 +65,10 @@ public class TownyResourcesSettings {
 		return getDouble(TownyResourcesConfigNodes.TOWN_RESOURCES_PRODUCTION_OCCUPYING_NATION_TAX_PERCENTAGE) / 100;
 	}
 
+	public static boolean isMaxStackSizeLockedTo64() {
+		return getBoolean(TownyResourcesConfigNodes.TOWN_RESOURCES_PRODUCTION_COLLECTION_FORCES_STACKSIZE_OF_64);
+	}
+
 	public static int getSumOfAllOfferDiscoveryProbabilityWeights() {
 		return sumOfAllOfferDiscoveryProbabilityWeights;
 	}


### PR DESCRIPTION
```
- town_resources.production.collection_forces_max_stacksize_of_64",
  - default: true
  - Forces TownyResources to give resources out with a max stack size of 64.
  - This is usually the case but you might have other plugins which will set a player's max stack size higher.
```